### PR TITLE
Depend on individual tokio crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,19 @@ keywords = ["quic", "future", "tokio", "protocol", "picoquic"]
 repository = "bkchr/picoquic-rs"
 
 [dependencies]
-tokio = "0.1"
+bytes = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
 futures = "0.1"
-bytes = "0.4"
-log = "0.4"
 libc = "0.2"
-socket2 = "0.3"
+log = "0.4"
 openssl = "^0.10.6"
 openssl-sys = "^0.9.28"
 parking_lot = "0.6"
+socket2 = "0.3"
+tokio-executor = "0.1"
+tokio-timer = "0.2"
+tokio-udp = "0.1"
 
 [dependencies.picoquic-sys]
 path = "./picoquic-sys/"
@@ -34,5 +36,6 @@ version = "0.1.0"
 
 [dev-dependencies]
 timebomb = "0.1"
+tokio = "0.1"
 
 [workspace]

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use error::*;
 
 use std::net::SocketAddr;
 
-use tokio::runtime::TaskExecutor;
+use tokio_executor::Executor;
 
 use futures::{
     sync::{mpsc::UnboundedReceiver, oneshot},
@@ -28,7 +28,7 @@ impl Context {
     /// name - Will be used as SNI for TLS.
     pub fn new(
         listen_address: &SocketAddr,
-        handle: TaskExecutor,
+        mut handle: impl Executor,
         config: Config,
     ) -> Result<Context, Error> {
         let (inner, recv_con, new_connection_handle, close_handle) =
@@ -37,7 +37,7 @@ impl Context {
         let local_addr = inner.local_addr();
 
         // start the inner future
-        handle.spawn(inner);
+        handle.spawn(Box::new(inner))?;
 
         Ok(Context {
             recv_con,

--- a/src/context_inner.rs
+++ b/src/context_inner.rs
@@ -16,7 +16,8 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::{net::UdpSocket, timer::Delay};
+use tokio_udp::UdpSocket;
+use tokio_timer::Delay;
 
 use futures::{
     sync::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,8 @@ use futures;
 
 use openssl;
 
+use tokio_executor::SpawnError;
+
 #[derive(Debug)]
 pub struct Error {
     inner: Context<ErrorKind>,
@@ -80,6 +82,12 @@ impl From<io::Error> for Error {
     }
 }
 
+impl From<SpawnError> for Error {
+    fn from(e: SpawnError) -> Error {
+        ErrorKind::Spawn(e).into()
+    }
+}
+
 #[derive(Debug, Fail)]
 pub enum ErrorKind {
     #[fail(display = "A network error occurred.")]
@@ -106,6 +114,8 @@ pub enum ErrorKind {
     Custom(failure::Error),
     #[fail(display = "IO error {}", _0)]
     Io(io::Error),
+    #[fail(display = "Spawn error {}", _0)]
+    Spawn(SpawnError)
 }
 
 //FIXME: Remove when upstream provides a better bail macro

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,9 @@ extern crate openssl_sys;
 extern crate parking_lot;
 extern crate picoquic_sys;
 extern crate socket2;
-extern crate tokio;
+extern crate tokio_executor;
+extern crate tokio_timer;
+extern crate tokio_udp;
 
 mod config;
 mod connection;


### PR DESCRIPTION
Instead of pulling in the complete `tokio` crate (which is meant mostly for applications), depend only on `tokio_executor`, `tokio_udp` and `tokio_timer`.